### PR TITLE
Fix buildable mechanoids' inheritance issues

### DIFF
--- a/1.4/Defs/ThingDefs_Races/Races_Machines.xml
+++ b/1.4/Defs/ThingDefs_Races/Races_Machines.xml
@@ -1,8 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-	<ThingDef ParentName="BaseMechanoid" Name="BaseVFEMachine" Abstract="True">
+	<ThingDef ParentName="BasePawn" Name="BaseVFEMachine" Abstract="True">
+		<soundImpactDefault>BulletImpact_Metal</soundImpactDefault>
 		<thingClass>VFEMech.Machine</thingClass>
+		<statBases>
+			<PsychicSensitivity>0.5</PsychicSensitivity>
+			<ToxicResistance>1</ToxicResistance>
+			<Flammability>0</Flammability>
+			<ComfyTemperatureMin>-100</ComfyTemperatureMin>
+			<ComfyTemperatureMax>250</ComfyTemperatureMax>
+			<MeatAmount>0</MeatAmount>
+			<ArmorRating_Heat>2.00</ArmorRating_Heat>
+		</statBases>
+		<receivesSignals>true</receivesSignals>
+		<race>
+			<fleshType>Mechanoid</fleshType>
+			<needsRest>false</needsRest>
+			<hasGenders>false</hasGenders>
+			<foodType>None</foodType>
+			<lifeExpectancy>2500</lifeExpectancy>
+			<bloodDef>Filth_MachineBits</bloodDef>
+		</race>
+		<comps>
+			<li Class="CompProperties_CanBeDormant" />
+			<li Class="CompProperties_WakeUpDormant">
+				<wakeUpOnDamage>true</wakeUpOnDamage>
+				<wakeUpCheckRadius>30</wakeUpCheckRadius>
+				<wakeUpSound>MechanoidsWakeUp</wakeUpSound>
+			</li>
+		</comps>
 	</ThingDef>
 
 	<ThingDef ParentName="BaseVFEMachine">

--- a/1.4/Defs/ThingDefs_Races/Races_Machines.xml
+++ b/1.4/Defs/ThingDefs_Races/Races_Machines.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
+	<ThingDef ParentName="BaseMechanoid" Name="BaseVFEMachine" Abstract="True">
+		<thingClass>VFEMech.Machine</thingClass>
+	</ThingDef>
+
 	<ThingDef ParentName="BaseVFEMachine">
 		<defName>VFE_Mechanoids_Autocleaner</defName>
 		<label>autocleaner</label>


### PR DESCRIPTION
The xml file for the buildable mechs in 1.4 lacks the nodes added in this PR which without this node, any patch that targets their parent def fails to work in 1.4 version of the mod since LoadFolder shenanigans somehow mess things up when it comes to getting inheritance from other versions of the mod i.e. inheritance from 1.3 folder when 1.4 is loaded.

In short, the lack of the nodes added here makes patches applied to the parent defs to not be applied/inherited for the child defs. Adding the specific node back fixes the issue.