### PR TITLE
Update JobDriver_Disassemble.cs

### DIFF
--- a/1.5/Source/VFEM/JobDrivers/JobDriver_Disassemble.cs
+++ b/1.5/Source/VFEM/JobDrivers/JobDriver_Disassemble.cs
@@ -49,6 +49,10 @@ namespace VFEMech
 		protected void FinishedRemoving()
 		{
 			this.Target.Destroy(DestroyMode.Refund);
+   			if (Find.PlaySettings.autoRebuild)
+			{
+	                	GenConstruct.PlaceBlueprintForBuild(this.Target.def, this.Target.Position, base.Map, this.Target.Rotation, Faction.OfPlayer, this.Target.Stuff);
+	            	}
 		}
 	}
 }


### PR DESCRIPTION
Makes Carpenters & Advanced Carpenters make blueprints/ghosts of buildings they disassemble if the player setting in the bottom right is checked.